### PR TITLE
Integrate LibreSSL + portability

### DIFF
--- a/include/win32netcompat.h
+++ b/include/win32netcompat.h
@@ -1,0 +1,78 @@
+/*
+ * Public domain
+ *
+ * BSD socket emulation code for Winsock2
+ * Brent Cook <bcook@openbsd.org>
+ */
+
+/*
+ * From
+ * https://raw.githubusercontent.com/libressl-portable/portable/master/include/compat/win32netcompat.h
+ * https://raw.githubusercontent.com/libressl-portable/portable/master/include/compat/arpa/inet.h
+ * https://raw.githubusercontent.com/libressl-portable/portable/master/include/compat/arpa/nameser.h
+ */
+
+#ifndef LIBCRYPTOCOMPAT_WIN32NETCOMPAT_H
+#define LIBCRYPTOCOMPAT_WIN32NETCOMPAT_H
+
+#ifdef _WIN32
+
+#include <ws2tcpip.h>
+#include <errno.h>
+#include <unistd.h>
+
+#ifndef SHUT_RDWR
+#define SHUT_RDWR SD_BOTH
+#endif
+#ifndef SHUT_RD
+#define SHUT_RD   SD_RECEIVE
+#endif
+#ifndef SHUT_WR
+#define SHUT_WR   SD_SEND
+#endif
+
+int posix_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
+
+int posix_close(int fd);
+ssize_t posix_read(int fd, void *buf, size_t count);
+
+ssize_t posix_write(int fd, const void *buf, size_t count);
+
+int posix_getsockopt(int sockfd, int level, int optname,
+  void *optval, socklen_t *optlen);
+
+int posix_setsockopt(int sockfd, int level, int optname,
+  const void *optval, socklen_t optlen);
+
+#ifndef NO_REDEF_POSIX_FUNCTIONS
+#define connect(sockfd, addr, addrlen) posix_connect(sockfd, addr, addrlen)
+#define close(fd) posix_close(fd)
+#define read(fd, buf, count) posix_read(fd, buf, count)
+#define write(fd, buf, count) posix_write(fd, buf, count)
+#define getsockopt(sockfd, level, optname, optval, optlen) \
+  posix_getsockopt(sockfd, level, optname, optval, optlen)
+#define setsockopt(sockfd, level, optname, optval, optlen) \
+  posix_setsockopt(sockfd, level, optname, optval, optlen)
+#endif
+
+#ifndef AI_ADDRCONFIG
+#define AI_ADDRCONFIG               0x00000400
+#endif
+
+#ifndef INADDRSZ
+#define INADDRSZ 4
+#endif
+
+#ifndef IN6ADDRSZ
+#define IN6ADDRSZ 16
+#endif
+
+#ifndef INT16SZ
+#define INT16SZ 2
+#endif
+
+int inet_pton(int af, const char * src, void * dst);
+
+#endif
+
+#endif

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,3 +1,6 @@
+require 'open3'
+require 'fileutils'
+
 MRuby::Gem::Specification.new('mruby-tls-openssl') do |spec|
   spec.license = 'MIT'
   spec.author  = 'Internet Initiative Japan Inc.'
@@ -5,9 +8,59 @@ MRuby::Gem::Specification.new('mruby-tls-openssl') do |spec|
   spec.add_dependency 'mruby-io'
   spec.add_dependency 'mruby-socket'
 
-  spec.cc.include_paths << "#{spec.dir}/openssldir/include"
-  spec.linker.library_paths << "#{spec.dir}/openssldir/lib"
+  openssl_dir = File.join(build_dir, "openssldir")
+  openssl_source_dir =  File.join(build_dir, "openssl_src_dir")
+
+  def run_command env, command
+    STDOUT.sync = true
+    puts "build: [exec] #{command}"
+    Open3.popen2e(env, command) do |stdin, stdout, thread|
+      print stdout.read
+      fail "#{command} failed" if thread.value != 0
+    end
+  end
+
+  def host_configure_option build
+    return "" unless build.kind_of?(MRuby::CrossBuild)
+    return "--host #{build.host_target}"
+  end
+
+  def flags_after_libraries build
+    return "" unless build.kind_of?(MRuby::CrossBuild)
+    return "-lws2_32" if build.host_target["w64"]
+  end
+
+  def build_dependency
+    FileUtils.mkdir_p openssl_dir
+
+    if !File.exists?(openssl_source_dir)
+      Dir.chdir(build_dir) do
+        e = {}
+        run_command e, "git clone https://github.com/libressl-portable/portable.git #{openssl_source_dir}"
+      end
+    end
+
+    if !File.exists?("#{openssl_dir}/lib/libssl.a")
+      Dir.chdir(openssl_source_dir) do
+        e = {
+          'CC' => "#{spec.build.cc.command} #{spec.build.cc.flags.join(' ')}",
+          'AR' => spec.build.archiver.command,
+        }
+        run_command e, "./autogen.sh" unless File.exists?("configure")
+        run_command e, "./configure --disable-shared --prefix=\"#{openssl_dir}\" #{host_configure_option(spec.build)}"
+        run_command e, "make"
+        run_command e, "make install"
+      end
+    end
+  end
+
+  build_dependency if ENV["BUILD_SSL_DEPENDENCY"]
+
+  spec.cc.include_paths << "#{openssl_dir}/include"
+  spec.linker.library_paths << "#{openssl_dir}/lib"
 
   spec.linker.libraries << 'ssl'
   spec.linker.libraries << 'crypto'
+
+  spec.linker.flags_after_libraries << flags_after_libraries(spec.build)
 end

--- a/src/inet_pton.c
+++ b/src/inet_pton.c
@@ -1,0 +1,211 @@
+/*  $OpenBSD: inet_pton.c,v 1.9 2015/01/16 16:48:51 deraadt Exp $ */
+// from https://raw.githubusercontent.com/libressl-portable/portable/master/crypto/compat/inet_pton.c
+
+/* Copyright (c) 1996 by Internet Software Consortium.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ * ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+ * CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+ * DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+ * PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ */
+#ifdef _WIN32
+#include <win32netcompat.h>
+#include <sys/types.h>
+#include <string.h>
+#include <errno.h>
+
+/*
+ * WARNING: Don't even consider trying to compile this on a system where
+ * sizeof(int) < 4.  sizeof(int) > 4 is fine; all the world's not a VAX.
+ */
+
+static int  inet_pton4(const char *src, u_char *dst);
+static int  inet_pton6(const char *src, u_char *dst);
+
+/* int
+ * inet_pton(af, src, dst)
+ *  convert from presentation format (which usually means ASCII printable)
+ *  to network format (which is usually some kind of binary format).
+ * return:
+ *  1 if the address was valid for the specified address family
+ *  0 if the address wasn't valid (`dst' is untouched in this case)
+ *  -1 if some other error occurred (`dst' is untouched in this case, too)
+ * author:
+ *  Paul Vixie, 1996.
+ */
+int
+inet_pton(int af, const char *src, void *dst)
+{
+  switch (af) {
+  case AF_INET:
+    return (inet_pton4(src, dst));
+  case AF_INET6:
+    return (inet_pton6(src, dst));
+  default:
+    errno = EAFNOSUPPORT;
+    return (-1);
+  }
+  /* NOTREACHED */
+}
+
+/* int
+ * inet_pton4(src, dst)
+ *  like inet_aton() but without all the hexadecimal and shorthand.
+ * return:
+ *  1 if `src' is a valid dotted quad, else 0.
+ * notice:
+ *  does not touch `dst' unless it's returning 1.
+ * author:
+ *  Paul Vixie, 1996.
+ */
+static int
+inet_pton4(const char *src, u_char *dst)
+{
+  static const char digits[] = "0123456789";
+  int saw_digit, octets, ch;
+  u_char tmp[INADDRSZ], *tp;
+
+  saw_digit = 0;
+  octets = 0;
+  *(tp = tmp) = 0;
+  while ((ch = *src++) != '\0') {
+    const char *pch;
+
+    if ((pch = strchr(digits, ch)) != NULL) {
+      u_int new = *tp * 10 + (pch - digits);
+
+      if (new > 255)
+        return (0);
+      if (! saw_digit) {
+        if (++octets > 4)
+          return (0);
+        saw_digit = 1;
+      }
+      *tp = new;
+    } else if (ch == '.' && saw_digit) {
+      if (octets == 4)
+        return (0);
+      *++tp = 0;
+      saw_digit = 0;
+    } else
+      return (0);
+  }
+  if (octets < 4)
+    return (0);
+
+  memcpy(dst, tmp, INADDRSZ);
+  return (1);
+}
+
+/* int
+ * inet_pton6(src, dst)
+ *  convert presentation level address to network order binary form.
+ * return:
+ *  1 if `src' is a valid [RFC1884 2.2] address, else 0.
+ * notice:
+ *  does not touch `dst' unless it's returning 1.
+ * credit:
+ *  inspired by Mark Andrews.
+ * author:
+ *  Paul Vixie, 1996.
+ */
+static int
+inet_pton6(const char *src, u_char *dst)
+{
+  static const char xdigits_l[] = "0123456789abcdef",
+        xdigits_u[] = "0123456789ABCDEF";
+  u_char tmp[IN6ADDRSZ], *tp, *endp, *colonp;
+  const char *xdigits, *curtok;
+  int ch, saw_xdigit, count_xdigit;
+  u_int val;
+
+  memset((tp = tmp), '\0', IN6ADDRSZ);
+  endp = tp + IN6ADDRSZ;
+  colonp = NULL;
+  /* Leading :: requires some special handling. */
+  if (*src == ':')
+    if (*++src != ':')
+      return (0);
+  curtok = src;
+  saw_xdigit = count_xdigit = 0;
+  val = 0;
+  while ((ch = *src++) != '\0') {
+    const char *pch;
+
+    if ((pch = strchr((xdigits = xdigits_l), ch)) == NULL)
+      pch = strchr((xdigits = xdigits_u), ch);
+    if (pch != NULL) {
+      if (count_xdigit >= 4)
+        return (0);
+      val <<= 4;
+      val |= (pch - xdigits);
+      if (val > 0xffff)
+        return (0);
+      saw_xdigit = 1;
+      count_xdigit++;
+      continue;
+    }
+    if (ch == ':') {
+      curtok = src;
+      if (!saw_xdigit) {
+        if (colonp)
+          return (0);
+        colonp = tp;
+        continue;
+      } else if (*src == '\0') {
+        return (0);
+      }
+      if (tp + INT16SZ > endp)
+        return (0);
+      *tp++ = (u_char) (val >> 8) & 0xff;
+      *tp++ = (u_char) val & 0xff;
+      saw_xdigit = 0;
+      count_xdigit = 0;
+      val = 0;
+      continue;
+    }
+    if (ch == '.' && ((tp + INADDRSZ) <= endp) &&
+        inet_pton4(curtok, tp) > 0) {
+      tp += INADDRSZ;
+      saw_xdigit = 0;
+      count_xdigit = 0;
+      break;  /* '\0' was seen by inet_pton4(). */
+    }
+    return (0);
+  }
+  if (saw_xdigit) {
+    if (tp + INT16SZ > endp)
+      return (0);
+    *tp++ = (u_char) (val >> 8) & 0xff;
+    *tp++ = (u_char) val & 0xff;
+  }
+  if (colonp != NULL) {
+    /*
+     * Since some memmove()'s erroneously fail to handle
+     * overlapping regions, we'll do the shift by hand.
+     */
+    const int n = tp - colonp;
+    int i;
+
+    if (tp == endp)
+      return (0);
+    for (i = 1; i <= n; i++) {
+      endp[- i] = colonp[n - i];
+      colonp[n - i] = 0;
+    }
+    tp = endp;
+  }
+  if (tp != endp)
+    return (0);
+  memcpy(dst, tmp, IN6ADDRSZ);
+  return (1);
+}
+#endif

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1,9 +1,12 @@
 #include <sys/types.h>
+#ifndef _WIN32
 #include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/wait.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#else
+#include <win32netcompat.h>
+#endif
+#include <sys/time.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Hi @tsahara,

I'm a [mruby-cli](https://github.com/hone/mruby-cli)'s contributor. When developing a mruby-cli app, it is important that its mruby gems are portable and can be easily built, including their own depdencies. It's in that context, that I suggest the present changes:
- automation of the building of the dependency LibreSSL
- make the gem portable on the targets targets linux, osx, win and architectures 32 and 64 bits.

What do you think?

One possible improvement I see, it's to let the developer choose which SSL lib and handle both cases.
